### PR TITLE
v2: Remove style panel on Image core block

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A WordPress plugin for enhancing the editorial experience, including some common
 - [What This Plugin Does](#what-this-plugin-does)
   - [Blocks](#blocks)
   - [Editor Plugins](#editor-plugins)
+  - [Core Enhancements](#core-enhancements)
 - [Theme Configuration](#theme-configuration)
 - [Theme API](#theme-api)
 - [Troubleshooting](#troubleshooting)
@@ -15,7 +16,7 @@ A WordPress plugin for enhancing the editorial experience, including some common
 
 ## What This Plugin Does
 
-The purpose of this plugin is to tailor the Gutenberg editor experience to be better suited to editors using their WordPress theme. Features added as a part of this plugin fall into two categories: block modifications and editor plugins.
+The purpose of this plugin is to tailor the Gutenberg editor experience to be better suited to editors using their WordPress theme and to add functionality common to many websites. Features added as a part of this plugin fall into three categories: block modifications, editor plugins, and core enhancements. This plugin also exposes some global functions that can be used in theme templates.
 
 ### Blocks
 
@@ -51,6 +52,10 @@ The Authors panel allows editors to assign multiple authors to the author byline
 
 These authors also serve as taxonomies for your articles, so archive pages full of an author's own content are auto-generated on your behalf.
 
+### Core Enhancements
+
+- Adds a `Credit` field to attachment posts.
+
 ### Template functions
 
 This plugin exposes a few functions that can be used to retrieve relevant values handled by the plugin. See the [Theme API](#theme-api) section for information about the available functions.
@@ -80,6 +85,7 @@ return array(
 		'table',
 		'video',
 	),
+  'enable_block_styles'  => array(),
 );
 ```
 
@@ -128,6 +134,14 @@ array(
 ```
 
 A list of blocks that are extended by the plugin. To disable the extension of a certain block, exclude it from this array.
+
+#### `enable_block_styles`
+
+**Allowed types:** `array`
+
+**Default value:** `array()`
+
+WordPress core includes style options for some core blocks. This plugin removes those style options by default, but this parameter can be used to re-enable the core style options for specific blocks. The following blocks have core styles that can be re-enabled via this parameter: `button`, `image`, `quote`, `separator`, `table`.
 
 ## Theme API
 

--- a/includes/Config.php
+++ b/includes/Config.php
@@ -33,6 +33,11 @@ class Config {
 			'table',
 			'video',
 		),
+
+		// Enable core block styles.
+		'enable_block_styles'  => array(
+			'button',
+		),
 	);
 
 	/**

--- a/includes/Config.php
+++ b/includes/Config.php
@@ -35,9 +35,7 @@ class Config {
 		),
 
 		// Enable core block styles.
-		'enable_block_styles'  => array(
-			'button',
-		),
+		'enable_block_styles'  => array(),
 	);
 
 	/**

--- a/includes/Meta/AttachmentCredit.php
+++ b/includes/Meta/AttachmentCredit.php
@@ -18,12 +18,12 @@ class AttachmentCredit {
 	 */
 	private $attachment_fields = array(
 		array(
-			'id' => 'credit',
-			'label' => 'Credit',
-			'input' => 'text',
-			'helps' => 'Provide credit to the creator',
+			'id'     => 'credit',
+			'label'  => 'Credit',
+			'input'  => 'text',
+			'helps'  => 'Provide credit to the creator',
 			'single' => true,
-		)
+		),
 	);
 
 	/**
@@ -35,7 +35,7 @@ class AttachmentCredit {
 		$attachment_credit = new self();
 
 		add_filter( 'attachment_fields_to_edit', array( $attachment_credit, 'register_edit_fields' ), 10, 2 );
-		add_filter( 'attachment_fields_to_save', array( $attachment_credit, 'handle_save_fields'), 10, 2 );
+		add_filter( 'attachment_fields_to_save', array( $attachment_credit, 'handle_save_fields' ), 10, 2 );
 
 		add_action( 'rest_api_init', array( $attachment_credit, 'register_rest_fields' ) );
 	}
@@ -72,7 +72,7 @@ class AttachmentCredit {
 	 * @param array $post       Array of post data.
 	 * @param array $attachment Attachment metadata.
 	 *
-	 * @return void
+	 * @return array
 	 */
 	public function handle_save_fields( $post, $attachment ) {
 		foreach ( $this->attachment_fields as $field ) {
@@ -93,12 +93,12 @@ class AttachmentCredit {
 	 * @return void
 	 */
 	public function register_rest_fields() {
-		foreach ($this->attachment_fields as $field) {
+		foreach ( $this->attachment_fields as $field ) {
 			register_rest_field(
 				'attachment',
 				$field['id'],
 				array(
-					'get_callback'    => function($object) use ($field) {
+					'get_callback'    => function( $object ) use ( $field ) {
 						return get_post_meta( $object['id'], $field['id'], $field['single'] );
 					},
 					'update_callback' => null,

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,10 @@ import { Cover, File, Gallery, ImageLayout, RelatedArticles, Table, Video } from
   });
 
 domReady(() => {
+  // Remove image style panel
+  unregisterBlockStyle('core/image', 'default');
+  unregisterBlockStyle('core/image', 'rounded');
+
   // Remove quote style panel
   unregisterBlockStyle('core/quote', 'default');
   unregisterBlockStyle('core/quote', 'plain');

--- a/src/index.js
+++ b/src/index.js
@@ -46,18 +46,22 @@ import { Cover, File, Gallery, ImageLayout, RelatedArticles, Table, Video } from
   });
 
 /**
- * Unregister block styles and variations on core blocks. This prevents
- * unnecessary options for content editors and gives designers a blank slate
- * when implementing core blocks.
+ * Unregister all block styles and variations on core blocks by default, with
+ * optional overrides provided in configuration. This prevents unnecessary
+ * options for content editors and gives designers a blank slate when
+ * implementing core blocks.
  *
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/
  */
 domReady(() => {
-  // Unregister core block styles.
-  ['core/image', 'core/quote', 'core/separator', 'core/table'].forEach(blockName => {
-    wp.blocks
-      .getBlockType(blockName)
-      .styles.forEach(({ name: styleName }) => unregisterBlockStyle(blockName, styleName));
+  const activeEnableBlockStyles = window.ups_editorial?.enable_block_styles;
+  ['button', 'image', 'quote', 'separator', 'table'].forEach(blockName => {
+    if (activeEnableBlockStyles && activeEnableBlockStyles.indexOf(blockName) === -1) {
+      blockName = 'core/' + blockName;
+      wp.blocks
+        .getBlockType(blockName)
+        .styles.forEach(({ name: styleName }) => unregisterBlockStyle(blockName, styleName));
+    }
   });
 
   // Unregister core Embed block variations.

--- a/src/index.js
+++ b/src/index.js
@@ -45,31 +45,29 @@ import { Cover, File, Gallery, ImageLayout, RelatedArticles, Table, Video } from
     });
   });
 
+/**
+ * Unregister block styles and variations on core blocks. This prevents
+ * unnecessary options for content editors and gives designers a blank slate
+ * when implementing core blocks.
+ *
+ * @see
+ * https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/
+ */
 domReady(() => {
-  // Remove image style panel
-  unregisterBlockStyle('core/image', 'default');
-  unregisterBlockStyle('core/image', 'rounded');
+  // Unregister core block styles.
+  ['core/image', 'core/quote', 'core/separator', 'core/table'].forEach(blockName => {
+    wp.blocks
+      .getBlockType(blockName)
+      .styles.forEach(({ name: styleName }) => unregisterBlockStyle(blockName, styleName));
+  });
 
-  // Remove quote style panel
-  unregisterBlockStyle('core/quote', 'default');
-  unregisterBlockStyle('core/quote', 'plain');
-
-  // Remove separator style panel
-  unregisterBlockStyle('core/separator', 'default');
-  unregisterBlockStyle('core/separator', 'wide');
-  unregisterBlockStyle('core/separator', 'dots');
-
-  // Remove table style panel
-  unregisterBlockStyle('core/table', 'regular');
-  unregisterBlockStyle('core/table', 'stripes');
-
-  // Updating format type
-  const image = unregisterFormatType('core/image');
-  image.className = 'wp-rich-text-inline-image';
-  registerFormatType('core/image', image);
-
-  // Unregister all the Embed block variations.
+  // Unregister core Embed block variations.
   getBlockVariations('core/embed').forEach(variation => {
     unregisterBlockVariation('core/embed', variation.name);
   });
+
+  // Update format type.
+  const image = unregisterFormatType('core/image');
+  image.className = 'wp-rich-text-inline-image';
+  registerFormatType('core/image', image);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,7 @@ import { Cover, File, Gallery, ImageLayout, RelatedArticles, Table, Video } from
  * unnecessary options for content editors and gives designers a blank slate
  * when implementing core blocks.
  *
- * @see
- * https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/
  */
 domReady(() => {
   // Unregister core block styles.

--- a/src/index.js
+++ b/src/index.js
@@ -46,10 +46,6 @@ import { Cover, File, Gallery, ImageLayout, RelatedArticles, Table, Video } from
   });
 
 domReady(() => {
-  // Remove button style panel
-  unregisterBlockStyle('core/button', 'fill');
-  unregisterBlockStyle('core/button', 'outline');
-
   // Remove image style panel
   unregisterBlockStyle('core/image', 'default');
   unregisterBlockStyle('core/image', 'rounded');

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,10 @@ import { Cover, File, Gallery, ImageLayout, RelatedArticles, Table, Video } from
   });
 
 domReady(() => {
+  // Remove button style panel
+  unregisterBlockStyle('core/button', 'fill');
+  unregisterBlockStyle('core/button', 'outline');
+
   // Remove image style panel
   unregisterBlockStyle('core/image', 'default');
   unregisterBlockStyle('core/image', 'rounded');

--- a/src/index.js
+++ b/src/index.js
@@ -45,36 +45,44 @@ import { Cover, File, Gallery, ImageLayout, RelatedArticles, Table, Video } from
     });
   });
 
-/**
- * Unregister all block styles and variations on core blocks by default, with
- * optional overrides provided in configuration. This prevents unnecessary
- * options for content editors and gives designers a blank slate when
- * implementing core blocks.
- *
- * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/
- */
-domReady(() => {
-  const activeEnableBlockStyles = window.ups_editorial?.enable_block_styles;
-  ['button', 'image', 'quote', 'separator', 'table'].forEach(blockName => {
-    if (activeEnableBlockStyles && activeEnableBlockStyles.indexOf(blockName) === -1) {
-      blockName = 'core/' + blockName;
-      wp.blocks
-        .getBlockType(blockName)
-        .styles.forEach(({ name: styleName }) => unregisterBlockStyle(blockName, styleName));
-    }
-  });
+// ========================
+// General editor
 
-  // Unregister core Embed block variations.
+domReady(() => {
+  /**
+   * Unregister all block styles and variations on core blocks by default, with
+   * optional overrides provided in configuration. This prevents unnecessary
+   * options for content editors and gives designers a blank slate when
+   * implementing core blocks.
+   *
+   * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/
+   */
+  const activeEnableBlockStyles = window.ups_editorial?.enable_block_styles;
+
+  console.log(activeEnableBlockStyles);
+  ['button', 'image', 'quote', 'separator', 'table']
+    .filter(
+      blockName => !activeEnableBlockStyles || activeEnableBlockStyles.indexOf(blockName) === -1,
+    )
+    .forEach(blockName =>
+      wp.blocks
+        .getBlockType(`core/${blockName}`)
+        .styles.forEach(({ name: styleName }) =>
+          unregisterBlockStyle(`core/${blockName}`, styleName),
+        ),
+    );
+
+  /**
+   * Unregister core Embed block variations.
+   */
   getBlockVariations('core/embed').forEach(variation => {
     unregisterBlockVariation('core/embed', variation.name);
   });
-});
 
-/**
- * Add custom class to inline images added to rich text content. This gives
- * theme designers a selector target for inline image styles.
- */
-domReady(() => {
+  /**
+   * Add custom class to inline images added to rich text content. This gives
+   * theme designers a selector target for inline image styles.
+   */
   const image = unregisterFormatType('core/image');
   image.className = 'wp-rich-text-inline-image';
   registerFormatType('core/image', image);

--- a/src/index.js
+++ b/src/index.js
@@ -65,8 +65,13 @@ domReady(() => {
   getBlockVariations('core/embed').forEach(variation => {
     unregisterBlockVariation('core/embed', variation.name);
   });
+});
 
-  // Update format type.
+/**
+ * Add custom class to inline images added to rich text content. This gives
+ * theme designers a selector target for inline image styles.
+ */
+domReady(() => {
   const image = unregisterFormatType('core/image');
   image.className = 'wp-rich-text-inline-image';
   registerFormatType('core/image', image);

--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,6 @@ domReady(() => {
    * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/
    */
   const activeEnableBlockStyles = window.ups_editorial?.enable_block_styles;
-
-  console.log(activeEnableBlockStyles);
   ['button', 'image', 'quote', 'separator', 'table']
     .filter(
       blockName => !activeEnableBlockStyles || activeEnableBlockStyles.indexOf(blockName) === -1,


### PR DESCRIPTION
## Changes

This removes the WordPress-provided style panels on ~`core/button` and~ `core/image` blocks. This works towards the goal of removing opinionated defaults and unneeded editor options.

**Edited to add: This image is old; the core/button block still has its styles.**
<img width="993" alt="image" src="https://user-images.githubusercontent.com/389936/219132515-4fb6c429-0612-43b4-af9d-84cbc9b8d62b.png">